### PR TITLE
batch send message has different styles between multiple or single message

### DIFF
--- a/lib/ex_aliyun/parser.ex
+++ b/lib/ex_aliyun/parser.ex
@@ -94,6 +94,9 @@ defmodule ExAliyun.MNS.Parser do
     message = Map.put(message, "MessageBody", Base.decode64!(message_body))
     Map.put(body, "Messages", [message])
   end
+  defp decode_message_body(%{"Messages" => %{"Message" => message}} = body) when is_map(message) do
+    Map.put(body, "Messages", [message])
+  end
   defp decode_message_body(%{"Messages" => %{"Message" => messages}} = body) when is_list(messages) do
     messages =
       Enum.map(messages, fn

--- a/test/queue_integration_test.exs
+++ b/test/queue_integration_test.exs
@@ -158,7 +158,7 @@ defmodule ExAliyunMNSTest.Queue.Integration do
 
     message = "Test"
 
-    {:ok, _response} = MNS.send_message(queue_url, message)
+    assert {:ok, %{body: %{"Message" => _resp_message}}} = MNS.send_message(queue_url, message)
 
     {:ok, response} = MNS.receive_message(queue_url)
 
@@ -170,9 +170,17 @@ defmodule ExAliyunMNSTest.Queue.Integration do
 
     assert error_code_and_message(response) == {"InvalidArgument", "The value of PollingWaitSeconds should between 0 and 30 seconds"}
 
+    messages = ["msg1"]
+    assert {:ok, %{body: %{"Messages" => resp_messages}}} = MNS.batch_send_message(queue_url, messages)
+    assert length(resp_messages) == 1
+
+    get_messages = receive_messages(queue_url, 3, 20)
+    assert length(get_messages) == 1
+
     messages = ["msg1", "msg2", "msg3"]
 
-    {:ok, _response} = MNS.batch_send_message(queue_url, messages)
+    assert {:ok, %{body: %{"Messages" => resp_messages}}} = MNS.batch_send_message(queue_url, messages)
+    assert is_list(resp_messages) == true
 
     messages1 = receive_messages(queue_url, 3, 20)
     messages2 = receive_messages(queue_url, 3, 20)


### PR DESCRIPTION
## Single Msg:
``` elixir
ExAliyun.MNS.batch_send_message("test-error", ["1"])
%{
  "Messages" => %{
    "Message" => %{
      "MessageBodyMD5" => "CDD96D3CC73D1DBDAFFA03CC6CD7339B",
      "MessageId" => "9D4C45ADF36E4E2D7FD1262C867ADE1A"
    }
  }
}

# expect:
%{
  "Messages" => [
    %{
      "MessageBodyMD5" => "CDD96D3CC73D1DBDAFFA03CC6CD7339B",
      "MessageId" => "9D4C45ADF36E4E2D7FD1262C867ADE1A"
    }
  ]
}
```

## Multiple Msg:
``` elixir
ExAliyun.MNS.batch_send_message("test-error", ["1", "2"])
%{
  "Messages" => [
    %{
      "MessageBodyMD5" => "0B7E7DEE87B1C3B98E72131173DFBBBF",
      "MessageId" => "9D4C45ADF36E4E2D7FD1262C9C58EBC8"
    },
    %{
      "MessageBodyMD5" => "CDD96D3CC73D1DBDAFFA03CC6CD7339B",
      "MessageId" => "9D4C45ADF36E4E2D7FD1262C9C58EBC7"
    }
  ]
}
```

