### PR TITLE
enhance: Unify the return values of list_* class interfaces

### DIFF
--- a/lib/ex_aliyun/mns.ex
+++ b/lib/ex_aliyun/mns.ex
@@ -200,6 +200,9 @@ defmodule ExAliyun.MNS do
 
       {:ok, %{status: 200, body: %{"Queues" => %{}} = body} = env} ->
         {:ok, %{env | body: %{body | "Queues" => %{"Queue" => []}}}}
+
+      other ->
+        other
     end
   end
 
@@ -427,6 +430,9 @@ defmodule ExAliyun.MNS do
 
       {:ok, %{status: 200, body: %{"Topics" => %{}} = body} = env} ->
         {:ok, %{env | body: %{body | "Topics" => %{"Topic" => []}}}}
+
+      other ->
+        other
     end
   end
 
@@ -530,6 +536,9 @@ defmodule ExAliyun.MNS do
 
       {:ok, %{status: 200, body: %{"Subscriptions" => %{}} = body} = env} ->
         {:ok, %{env | body: %{body | "Subscriptions" => %{"Subscription" => []}}}}
+
+      other ->
+        other
     end
   end
 

--- a/test/publish_message_to_queue_test.exs
+++ b/test/publish_message_to_queue_test.exs
@@ -35,8 +35,7 @@ defmodule ExAliyunMNSTest.PublishMessageToQueue do
 
     subscription_name = "test-subname"
     queue_name = String.split(queue_url, "/") |> List.last()
-
-    endpoint = "acs:mns:cn-shenzhen:1570283091764072:queues/#{queue_name}"
+    endpoint = queue_endpoint(queue_name)
 
     {:ok, _response} =
       MNS.subscribe(topic_url, subscription_name, endpoint, notify_content_format: "SIMPLIFIED")
@@ -68,7 +67,7 @@ defmodule ExAliyunMNSTest.PublishMessageToQueue do
     sub_names =
       Enum.map(queue_urls, fn queue_url ->
         queue_name = String.split(queue_url, "/") |> List.last()
-        endpoint = "acs:mns:cn-shenzhen:1570283091764072:queues/#{queue_name}"
+        endpoint = queue_endpoint(queue_name)
         subscription_name = "#{queue_name}-sub"
 
         {:ok, _} =
@@ -103,5 +102,11 @@ defmodule ExAliyunMNSTest.PublishMessageToQueue do
       MNS.delete_message(queue_url, receipt_handle)
     end)
     |> Enum.to_list()
+  end
+
+  defp queue_endpoint(queue_name) do
+    url = Application.get_env(:ex_aliyun_mns, :host) |> URI.parse()
+    [id, "mns", region, "aliyuncs", "com"] = String.split(url.host, ".")
+    "acs:mns:#{region}:#{id}:queues/#{queue_name}"
   end
 end


### PR DESCRIPTION
# list_queues

- empty return
```elixir
ExAliyun.MNS.list_queues()
%{"Queues" => %{"Queue" => []}
```

- one return
```elixir
ExAliyun.MNS.list_queues()
%{"Queues" => %{"Queue" => [queue_info = %{}]}
```

- multiple return
```elixir
ExAliyun.MNS.list_queues()
%{"Queues" => %{"Queue" => [queue_info1, queue_info2, queue_info3]}
```

# list_topics

- empty return
```elixir
ExAliyun.MNS.list_topics()
%{"Topics" => %{"Topic" => []}
```

- one return
```elixir
ExAliyun.MNS.list_topics()
%{"Topics" => %{"Topic" => [topic_info = %{}]}
```

- multiple return
```elixir
ExAliyun.MNS.list_topics()
%{"Topics" => %{"Topic" => [topic_info1, topic_info2, topic_info3]}
```


# list_subscriptions

- empty return
```elixir
ExAliyun.MNS.list_subscriptions()
%{"Subscriptions" => %{"Subscription" => []}
```

- one return
```elixir
ExAliyun.MNS.list_subscriptions()
%{"Subscriptions" => %{"Subscription" => [subscription_info = %{}]}
```

- multiple return
```elixir
ExAliyun.MNS.list_subscriptions()
%{"Subscriptions" => %{"Subscription" => [subscription_info1, subscription_info2, subscription_info3]}
```